### PR TITLE
Make all LLM calls async

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,12 +212,7 @@ What companies are prominent adopters of the open-source technologies my team is
 Study my meeting notes to figure out the capabilities of the projects I’m involved in. Then, find me other open-source projects with similar features.
 ```
 
----
 
-# ⚠️ Important Notes
-
-- **Open WebUI 0.5 (Released 12/25/24) introduced performance improvements.**
-- Some users report occasional issues where chat results **don’t appear until refreshing the browser**.
 
 
 


### PR DESCRIPTION
Switching all of the LLM calls to async fixes the following issues:
- Chat results don't show up until browser is refreshed
- Status emitters don't always show up in a timely fashion to the UI, or at all
- Unable to reliably hit "stop" when the agent begins running